### PR TITLE
Disabled implicit usings

### DIFF
--- a/CSS Server/CSS Server.csproj
+++ b/CSS Server/CSS Server.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <!--<Nullable>enable</Nullable>-->
-    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>disable</ImplicitUsings>
     <RootNamespace>CSS_Server</RootNamespace>
   </PropertyGroup>
 

--- a/CSS Server/Controllers/CameraController.cs
+++ b/CSS Server/Controllers/CameraController.cs
@@ -2,6 +2,8 @@
 using CSS_Server.Models;
 using CSS_Server.ViewModels;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace CSS_Server.Controllers
 {

--- a/CSS Server/JsonProvider/CameraJsonProvider.cs
+++ b/CSS Server/JsonProvider/CameraJsonProvider.cs
@@ -1,5 +1,6 @@
 ﻿using CSS_Server.Models;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace CSS_Server.JsonProvider
 {

--- a/CSS Server/Models/CameraManager.cs
+++ b/CSS Server/Models/CameraManager.cs
@@ -1,4 +1,6 @@
-﻿namespace CSS_Server.Models
+﻿using System.Collections.Generic;
+
+namespace CSS_Server.Models
 {
     public sealed class CameraManager
     {

--- a/CSS Server/Program.cs
+++ b/CSS Server/Program.cs
@@ -1,3 +1,7 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
 var builder = WebApplication.CreateBuilder(args);
 
 //// Add services to the container.

--- a/CSS Server/ViewModels/CameraIndexViewModel.cs
+++ b/CSS Server/ViewModels/CameraIndexViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CSS_Server.Models;
+using System.Collections.Generic;
 
 namespace CSS_Server.ViewModels
 {


### PR DESCRIPTION
CodeQL does not support C# 10.0 fully yet, and couldn't figure out
the implicit usings. In C# 9.0, these implicit usings are not
supported at all. Disable implicit usings for now.
Also added the necessary usings everywhere.

Should fix the warnings of #4.