### PR TITLE
feat: ILogger class for future database logging

### DIFF
--- a/CSS Server/Models/Logger/DatabaseLogger.cs
+++ b/CSS Server/Models/Logger/DatabaseLogger.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CSS_Server.Models.Logger
+{
+    public class DatabaseLogger : ILogger
+    {
+        protected readonly DatabaseLoggerProvider _databaseLoggerProvider;
+        private readonly Func<DatabaseLoggerConfiguration> _getConfig;
+
+        public DatabaseLogger([NotNull]DatabaseLoggerProvider databaseLoggerProvider, Func<DatabaseLoggerConfiguration> getConfig)
+        {
+            _databaseLoggerProvider = databaseLoggerProvider;
+            _getConfig = getConfig;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return logLevel != LogLevel.None;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel) || state == null || eventId.Id != _getConfig().EventId)
+                return;
+
+            Console.WriteLine("lvl: " + logLevel + " eventid: " + eventId.Id + " Database logger! Heck yea! " + formatter(state, exception));
+        }
+    }
+}

--- a/CSS Server/Models/Logger/DatabaseLoggerConfiguration.cs
+++ b/CSS Server/Models/Logger/DatabaseLoggerConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace CSS_Server.Models.Logger
+{
+    public class DatabaseLoggerConfiguration
+    {
+        public int EventId { get; set; }
+    }
+}

--- a/CSS Server/Models/Logger/DatabaseLoggerExtensions.cs
+++ b/CSS Server/Models/Logger/DatabaseLoggerExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace CSS_Server.Models.Logger
+{
+    public static class DatabaseLoggerExtensions
+    {
+        public static ILoggingBuilder AddDatabase(this ILoggingBuilder builder)
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, DatabaseLoggerProvider>());
+            
+            return builder;
+        }
+    }
+}

--- a/CSS Server/Models/Logger/DatabaseLoggerProvider.cs
+++ b/CSS Server/Models/Logger/DatabaseLoggerProvider.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CSS_Server.Models.Logger
+{
+    [ProviderAlias("DatabaseLogger")]
+    public class DatabaseLoggerProvider : ILoggerProvider
+    {
+        private readonly DatabaseLoggerConfiguration _config;
+        private readonly DatabaseLogger _databaseLogger;
+
+        public DatabaseLoggerProvider(IOptionsMonitor<DatabaseLoggerConfiguration> config)
+        {
+            _config = config.CurrentValue;
+            _databaseLogger = new DatabaseLogger(this, GetConfig);
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _databaseLogger;
+        }
+
+        private DatabaseLoggerConfiguration GetConfig() => _config;
+
+        public void Dispose()
+        {
+
+        }
+    }
+}

--- a/CSS Server/Program.cs
+++ b/CSS Server/Program.cs
@@ -1,5 +1,6 @@
 using CSS_Server.JsonProvider;
 using CSS_Server.Models;
+using CSS_Server.Models.Logger;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -10,6 +11,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
 builder.Logging.AddDebug();
+builder.Logging.AddDatabase();
 
 builder.Services.AddSingleton<CameraJsonProvider>();
 builder.Services.AddSingleton<CameraManager>();

--- a/CSS Server/appsettings.Development.json
+++ b/CSS Server/appsettings.Development.json
@@ -4,6 +4,11 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "DatabaseLogger": {
+      "LogLevel": {
+        "Default": "Information"
+      }
     }
   }
 }

--- a/CSS Server/appsettings.json
+++ b/CSS Server/appsettings.json
@@ -3,6 +3,11 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "DatabaseLogger": {
+      "LogLevel": {
+        "Default": "Information"
+      }
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Program.cs:
- add: Configure the DatabaseLogger during startup.

appsettings:
- add: Use the DatabaseLogger for development and in general.

DatabaseLogger:
- add: stub ILogger implementation, for future database logging.
For now, it logs to the console.

The DatabaseLoggerExtensions class is used to create a new
DatabaseLoggerProvider, which creates the custom logger on startup.
When another class needs to create a logger for a specific category,
the provider provides the same logger for each category.

The DatabaseLoggerConfiguration contains an EventId for now, but could
contain more configuration options in the future.