### PR TITLE
fix: Connection disposed using deferred execution

### DIFF
--- a/CSS Server/Models/Database/Repositories/IRepository.cs
+++ b/CSS Server/Models/Database/Repositories/IRepository.cs
@@ -1,4 +1,5 @@
 using CSS_Server.Models.Database.DBObjects;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace CSS_Server.Models.Database
@@ -7,7 +8,7 @@ namespace CSS_Server.Models.Database
     {
         T Get(int id);
         void Delete(int id);
-        IQueryable<T> GetAll();
+        List<T> GetAll();
         void Update(T entity);
         void Insert(T entity);
     }

--- a/CSS Server/Models/Database/Repositories/SQLiteRepository.cs
+++ b/CSS Server/Models/Database/Repositories/SQLiteRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using CSS_Server.Models.Database.DBObjects;
@@ -35,11 +36,11 @@ namespace CSS_Server.Models.Database.Repositories
             return connection.CreateCommand(sql, id).ExecuteQuery<T>().FirstOrDefault();
         }
 
-        public IQueryable<T> GetAll()
+        public List<T> GetAll()
         {
             using SQLiteConnection connection = DatabaseHandler.Instance.CreateConnection();
             var query = new TableQuery<T>(connection);
-            return query.AsQueryable<T>();
+            return query.AsQueryable<T>().ToList<T>();
         }
 
         public void Insert(T entity)


### PR DESCRIPTION
When returning an IQueryable, the actual database query was executed
when the database connection was already disposed. To fix this, the
query is executed in the GetAll implementation, which now returns a
List.