### PR TITLE
fix: Remove WebCompiler from .csproj.

### DIFF
--- a/CSS Server/CSS Server.csproj
+++ b/CSS Server/CSS Server.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BuildWebCompiler" Version="1.12.405" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="sqlite-net-sqlcipher" Version="1.8.116" />


### PR DESCRIPTION
Removing the webcompiler from the .csproj file will disable compiling
SCSS on the CI, which should hopefully fix the current failure.