### PR TITLE
feat/fix: Message class, allocate buffer properly

### DIFF
--- a/CSS Server/Controllers/CameraController.cs
+++ b/CSS Server/Controllers/CameraController.cs
@@ -67,11 +67,11 @@ namespace CSS_Server.Controllers
                 return View(new CameraFootageViewModel()
                 {
                     CameraId = -1,
-                    CameraName = "Unknown or Oflline",
-            }); 
+                    CameraName = "Unknown or Offline",
+                }); 
             }
 
-            JArray footage = null;
+            List<string> footage = null;
 
             // Declare handler for receiving event.
             EventHandler<FootageAllReceivedEventArgs> footageReceivedHandler = (sender, e) =>
@@ -83,10 +83,7 @@ namespace CSS_Server.Controllers
             camera.CameraConnection.FootageAllReceived += footageReceivedHandler;
 
             //make footage_all request to camera
-            JObject request = new();
-            request["type"] = MessageType.FOOTAGE_REQUEST_ALL.ToString();
-
-            await camera.CameraConnection.Send(request);
+            await camera.CameraConnection.SendAsync(new Message(MessageType.FOOTAGE_REQUEST_ALL));
 
             //wait for the event to happen
             while(footage == null)

--- a/CSS Server/Models/EventArgs/FootageAllReceivedEventArgs.cs
+++ b/CSS Server/Models/EventArgs/FootageAllReceivedEventArgs.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Collections.Generic;
 
 namespace CSS_Server.Models.EventArgs
 {
     public class FootageAllReceivedEventArgs
     {
-        public JArray Footage { get; set; }
+        public List<string> Footage { get; set; }
     }
 }

--- a/CSS Server/Models/Message.cs
+++ b/CSS Server/Models/Message.cs
@@ -1,0 +1,42 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Collections.Generic;
+
+namespace CSS_Server.Models
+{
+    /// <summary>
+    /// Represents a complete message, used to communicate between the camera
+    /// client and the server.
+    /// </summary>
+    public class Message
+    {
+        [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public MessageType Type { get; }
+
+        [JsonProperty("id")]
+        public int CameraID { get; set; }
+
+        [JsonProperty("password")]
+        public string Password { get; set; }
+
+        // TODO: List<Footage> where Footage holds the filename and thumbnail.
+        [JsonProperty("footage")]
+        public List<string> Footage { get; set; }
+
+        public Message(MessageType type)
+        {
+            Type = type;
+        }
+
+        public static Message FromJson(string json)
+        {
+            return JsonConvert.DeserializeObject<Message>(json);
+        }
+
+        public static string ToJson(Message message)
+        {
+            return JsonConvert.SerializeObject(message);
+        }
+    }
+}

--- a/CSS Server/ViewModels/CameraFootageViewModel.cs
+++ b/CSS Server/ViewModels/CameraFootageViewModel.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace CSS_Server.ViewModels
 {
     public class CameraFootageViewModel
     {
-        public JArray Footage { get; set; }
+        public List<string> Footage { get; set; }
         public int CameraId { get; set; }
         public string CameraName { get; set; }
     }

--- a/CSS Server/Views/Camera/Footage.cshtml
+++ b/CSS Server/Views/Camera/Footage.cshtml
@@ -15,11 +15,11 @@
     {
         <div class="cameras-container">
 
-            @foreach (JObject footage in Model.Footage)
+            @foreach (string footage in Model.Footage)
             {
                 <div class="single-camera-block">
                     <img src="media/camerafootage.jpg" alt="footage">
-                    <h2>@footage["filename"]</h2>
+                    <h2>@footage</h2>
                 </div>
             }
         </div>


### PR DESCRIPTION
Notable changes:
- Added convenience Message class for serializing and deserializing
messages between the server and client. The messages can be
(de)serialized from and to JSON.
- The websocket receive() implementation has been placed in it's own
method, and allocates the receive buffer size properly by reading the
size bytes which the client sends upfront.

The way the footage data is send has been changed slightly: before,
each element in the footage array contained a JSON object with only
one key-value pair. This has been changed to just an array of strings,
which represent the filenames. This can be changed in the future to
allow for thumbnails.