### PR TITLE
fix: Don't crash when websocket is aborted

### DIFF
--- a/CSS Server/Controllers/CameraController.cs
+++ b/CSS Server/Controllers/CameraController.cs
@@ -142,7 +142,14 @@ namespace CSS_Server.Controllers
                 }
                 else
                 {
-                    await webSocket.CloseAsync(WebSocketCloseStatus.ProtocolError, "Validation Error", CancellationToken.None);
+                    try
+                    {
+                        await webSocket.CloseAsync(WebSocketCloseStatus.ProtocolError, "Validation Error", CancellationToken.None);
+                    }
+                    catch (WebSocketException ex)
+                    {
+                        _logger.LogDebug("Websocket errored while closing after invalid message: " + ex.Message);
+                    }
                 }
 
 

--- a/CSS Server/Models/CameraManager.cs
+++ b/CSS Server/Models/CameraManager.cs
@@ -45,7 +45,7 @@ namespace CSS_Server.Models
             // Check if the message is valid.
             if (message == null || message.Type != MessageType.LOGIN || message.Password == null || message.CameraID < 1)
             {
-                _logger.LogDebug("Camera sent invalid message!");
+                _logger.LogInformation("Camera sent invalid message!");
                 return null;
             }
 


### PR DESCRIPTION
Also, validation errors are now logged with the normal loglevel.