### PR TITLE
Connnection improvements

### DIFF
--- a/CSS Server/Controllers/CameraController.cs
+++ b/CSS Server/Controllers/CameraController.cs
@@ -200,7 +200,7 @@ namespace CSS_Server.Controllers
         {
             if (HttpContext.WebSockets.IsWebSocketRequest)
             {
-                //accept the incoming websocket connection:
+                // Accept the incoming websocket connection.
                 using WebSocket webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync();
                 Camera camera = await _cameraManager.ValidateCameraConnection(webSocket);
 
@@ -208,6 +208,7 @@ namespace CSS_Server.Controllers
                 {
                     camera.CameraConnection = new CameraConnection(webSocket, _logger);
                     await camera.CameraConnection.StartReading();
+                    await camera.CameraConnection.Close();
                 }
                 else
                 {
@@ -220,11 +221,6 @@ namespace CSS_Server.Controllers
                         _logger.LogDebug("Websocket errored while closing after invalid message: " + ex.Message);
                     }
                 }
-
-
-                // it is also possible to allow compression:
-                //using (WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync(
-                //    new WebSocketAcceptContext() { DangerousEnableCompression = true }))
             }
             else
             {

--- a/CSS Server/Models/CameraConnection.cs
+++ b/CSS Server/Models/CameraConnection.cs
@@ -26,15 +26,21 @@ namespace CSS_Server.Models
         {
             if (_webSocket != null)
             {
-                await _webSocket.CloseAsync(WebSocketCloseStatus.Empty, "The connection was closed by the server.", CancellationToken.None);
-                return true;
+                try
+                {
+                    await _webSocket.CloseAsync(WebSocketCloseStatus.Empty, null, CancellationToken.None);
+                    return true;
+                }
+                catch (WebSocketException ex)
+                {
+                    _logger.LogDebug(ex.Message);
+                }
             }
             return false;
         }
 
         public async Task StartReading()
         {
-            
             while (_webSocket != null && _webSocket.State == WebSocketState.Open)
             {
                 Message message = await ReceiveMessageAsync(_webSocket);
@@ -42,6 +48,8 @@ namespace CSS_Server.Models
                 if (message != null)
                     HandleReceivedMessage(message);
             }
+
+            _logger.LogInformation("Stopping reading websocket with state: " + _webSocket.State);
         }
 
         private void HandleReceivedMessage(Message message)

--- a/CSS Server/Models/CameraConnection.cs
+++ b/CSS Server/Models/CameraConnection.cs
@@ -24,12 +24,16 @@ namespace CSS_Server.Models
 
         public async Task<bool> Close()
         {
-            if (_webSocket != null)
+            if (_webSocket != null && _webSocket.State != WebSocketState.Aborted)
             {
                 try
                 {
                     await _webSocket.CloseAsync(WebSocketCloseStatus.Empty, null, CancellationToken.None);
                     return true;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogDebug(ex.Message);
                 }
                 catch (WebSocketException ex)
                 {
@@ -49,7 +53,7 @@ namespace CSS_Server.Models
                     HandleReceivedMessage(message);
             }
 
-            _logger.LogInformation("Stopping reading websocket with state: " + _webSocket.State);
+            _logger.LogInformation("Stopping reading websocket with state: " + _webSocket?.State);
         }
 
         private void HandleReceivedMessage(Message message)

--- a/CSS Server/Startup.cs
+++ b/CSS Server/Startup.cs
@@ -114,7 +114,7 @@ namespace CSS_Server
 
             app.UseWebSockets(new WebSocketOptions()
             {
-                KeepAliveInterval = TimeSpan.FromSeconds(120)
+                KeepAliveInterval = TimeSpan.FromSeconds(30)
             });
 
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
- When closing the connection with the Empty statuscode, the status
description must be empty, otherwise an ArgumentException will be
thrown.
- Close websocket connection when camera connects but there is already
a connection open.
- Catch the websocket aborted state, and OperationCanceledException
when closing.
- Change timeout to 30 seconds instead of 2 minutes.