### PR TITLE
Prevent Cross Site Request Forgery (CSRF)

### DIFF
--- a/CSS Server/Controllers/CameraController.cs
+++ b/CSS Server/Controllers/CameraController.cs
@@ -109,7 +109,10 @@ namespace CSS_Server.Controllers
                 ViewData["AlreadyPosted"] = true;
 
             if (!ModelState.IsValid || Request.Method == "GET")
+            {
+                ViewData["Title"] = "CSS: Register camera";
                 return View(form);
+            }
 
             //TODO add proper validation
             if(_cameraJsonProvider.RegisterCamera(form.Name, form.Description, form.Password, new BaseUser(User)))

--- a/CSS Server/Startup.cs
+++ b/CSS Server/Startup.cs
@@ -2,11 +2,10 @@
 using CSS_Server.Models;
 using CSS_Server.Models.Authentication;
 using CSS_Server.Models.Database;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +36,11 @@ namespace CSS_Server
             services.AddControllersWithViews()
                 .AddNewtonsoftJson()
                 .AddRazorRuntimeCompilation();
+
+            services.AddMvc(options =>
+            {
+                options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
+            });
 
             services.AddDbContext<CSSContext>(options => 
                 options.UseSqlite(CSSContext.connectionString));

--- a/CSS Server/Views/Account/Index.cshtml
+++ b/CSS Server/Views/Account/Index.cshtml
@@ -1,6 +1,7 @@
 ﻿@using CSS_Server.Models.Authentication
 @using CSS_Server.ViewModels
 @using CSS_Server.Models
+@inject Microsoft.AspNetCore.Antiforgery.IAntiforgery AntiForgery
 
 @{
     Layout = "_Layout";
@@ -11,7 +12,7 @@
 <main class="main_dashboard">
     <button class="addButton" title="Register a new user">+</button>
     <h1>Users</h1>
-
+    <div id="AntiForgeryToken">@AntiForgery.GetAndStoreTokens(Context).RequestToken</div>
     <table>
         <thead>
             <tr>

--- a/CSS Server/Views/Account/LogIn.cshtml
+++ b/CSS Server/Views/Account/LogIn.cshtml
@@ -32,6 +32,7 @@
 
 <main class="main_form center">
     <form action="#" method="post">
+    @Html.AntiForgeryToken()
         <h1>
             CameraSecuritySystem
         </h1>

--- a/CSS Server/Views/Account/Register.cshtml
+++ b/CSS Server/Views/Account/Register.cshtml
@@ -35,6 +35,7 @@
             <h1>
             Register a new User
         </h1>
+        @Html.AntiForgeryToken()
         <div class="inputBox">
             <label for="UserName">UserName</label>
             <input asp-for="UserName" name="UserName" type="text" value="@Model.UserName">

--- a/CSS Server/Views/Account/Update.cshtml
+++ b/CSS Server/Views/Account/Update.cshtml
@@ -36,6 +36,7 @@
             Update user
         </h1>
 
+        @Html.AntiForgeryToken()
         <div class="inputBox">
             <label for="UserName">UserName</label>
             <div name="Username">@ViewData["userName"]</div>

--- a/CSS Server/Views/Camera/Index.cshtml
+++ b/CSS Server/Views/Camera/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@using CSS_Server.Models
+@inject Microsoft.AspNetCore.Antiforgery.IAntiforgery AntiForgery
 
 @{
     Layout = "_Layout";
@@ -9,6 +10,8 @@
 <main class="main_dashboard">
     <button class="addButton" title="Register a new camera">+</button>
     <h1>Camera's</h1>
+    <div id="AntiForgeryToken">@AntiForgery.GetAndStoreTokens(Context).RequestToken</div>
+
     <div class="cameras-container">
 
     @foreach (Camera camera in Model)

--- a/CSS Server/Views/Camera/Register.cshtml
+++ b/CSS Server/Views/Camera/Register.cshtml
@@ -35,7 +35,7 @@
         <h1>
             Register a new Camera
         </h1>
-
+        @Html.AntiForgeryToken()
         <div class="inputBox">
             <label for="Name">Name</label>
             <input asp-for="Name" name="Name" type="text" value="@Model.Name">

--- a/CSS Server/Views/Camera/Update.cshtml
+++ b/CSS Server/Views/Camera/Update.cshtml
@@ -32,6 +32,7 @@
 
 <main class="main_form">
     <form action="#" method="post">
+    @Html.AntiForgeryToken()
         <h1>
             Update @ViewData["cameraName"]
         </h1>

--- a/CSS Server/wwwroot/css/general.scss
+++ b/CSS Server/wwwroot/css/general.scss
@@ -203,6 +203,10 @@ nav {
     }
 }
 
+#AntiForgeryToken {
+    display: none;
+}
+
 //Begin icons
 .icon {
     display: inline-block;
@@ -210,7 +214,6 @@ nav {
     font-weight: 900;
     font-size: 20px;
     cursor: pointer;
-
 }
 .trashbin {
     @extend .icon;

--- a/CSS Server/wwwroot/js/AccountIndex.js
+++ b/CSS Server/wwwroot/js/AccountIndex.js
@@ -25,6 +25,12 @@ function trashbinOnClick(event, userRow, userId) {
         var xhr = new XMLHttpRequest();
         xhr.open("DELETE", url);
 
+        //Set the antiForgeryToken if it is available.
+        var antiForgery = document.getElementById("AntiForgeryToken");
+        if (antiForgery) {
+            xhr.setRequestHeader("RequestVerificationToken", antiForgery.innerText);
+        }
+
         //define a function for letting the user know that the user is deleted succesfully (or not).
         xhr.onload = function () {
             var snackbar = document.getElementById("snackbar");

--- a/CSS Server/wwwroot/js/CameraIndex.js
+++ b/CSS Server/wwwroot/js/CameraIndex.js
@@ -12,6 +12,12 @@ function trashbinOnClick(event, cameraBlock, cameraId) {
         var xhr = new XMLHttpRequest();
         xhr.open("DELETE", url);
 
+        //Set the antiForgeryToken if it is available.
+        var antiForgery = document.getElementById("AntiForgeryToken");
+        if (antiForgery) {
+            xhr.setRequestHeader("RequestVerificationToken", antiForgery.innerText);
+        }
+
         //define a function for letting the user know that the camera is deleted succesfully (or not).
         xhr.onload = function () {
             var snackbar = document.getElementById("snackbar");


### PR DESCRIPTION
Update of the most views:
Added request forgery tokens to the form.

In startup the AutoValidateAntiForgeryToken attribute is now passed to each endpoint. This attribute will enable validation of  anti forgery tokens by default on all unsafe requests.

In the AccountIndex.js and CameraIndex.js files I had to add some code to get the tokens from the dom. These tokens will then passed to the request which will delete the account or camera.

In cameracontroller:
Added a title