### PR TITLE
fix: Configure instead of use Kestrel

### DIFF
--- a/CSS Server/Program.cs
+++ b/CSS Server/Program.cs
@@ -37,7 +37,7 @@ namespace CSS_Server
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseKestrel(options =>
+                    webBuilder.ConfigureKestrel(options =>
                     {
                         options.AddServerHeader = false;
                     });


### PR DESCRIPTION
Calling UseKestrel when running on IIS will throw an
InvalidOperationException, since UseKestrel is already called inside
ConfigureWebHostDefaults.